### PR TITLE
Add issue templates for the various F@H subcomponents

### DIFF
--- a/.github/ISSUE_TEMPLATE/fah-client-bug.md
+++ b/.github/ISSUE_TEMPLATE/fah-client-bug.md
@@ -1,0 +1,22 @@
+---
+name: FAHClient bug report
+about: If a bug in the Folding@home client doesn't fit another category, click here.
+title: ''
+labels: FAHClient, defect
+assignees: ''
+
+---
+
+## Environment
+
+* OS:
+* FAH version:
+
+## What were you trying to do
+<!--And what was the expected behaviour?-->
+
+## What happened
+<!--A clear and concise description of what the bug is.-->
+
+## To Reproduce
+<!--Steps to reproduce the behavior, if possible.-->

--- a/.github/ISSUE_TEMPLATE/fah-control-bug.md
+++ b/.github/ISSUE_TEMPLATE/fah-control-bug.md
@@ -1,0 +1,22 @@
+---
+name: FAHControl bug report
+about: Create a report about a bug in the Advanced Control GUI.
+title: ''
+labels: FAHControl, defect
+assignees: ''
+
+---
+
+## Environment
+
+* OS:
+* FAH version:
+
+## What were you trying to do
+<!--And what was the expected behaviour?-->
+
+## What happened
+<!--A clear and concise description of what the bug is.-->
+
+## To Reproduce
+<!--Steps to reproduce the behavior, if possible.-->

--- a/.github/ISSUE_TEMPLATE/fah-viewer-bug.md
+++ b/.github/ISSUE_TEMPLATE/fah-viewer-bug.md
@@ -1,0 +1,22 @@
+---
+name: FAHViewer bug report
+about: Create a report about a bug in the Protein Viewer.
+title: ''
+labels: FAHViewer, defect
+assignees: ''
+
+---
+
+## Environment
+
+* OS:
+* FAH version:
+
+## What were you trying to do
+<!--And what was the expected behaviour?-->
+
+## What happened
+<!--A clear and concise description of what the bug is.-->
+
+## To Reproduce
+<!--Steps to reproduce the behavior, if possible.-->

--- a/.github/ISSUE_TEMPLATE/ux-report.md
+++ b/.github/ISSUE_TEMPLATE/ux-report.md
@@ -1,0 +1,17 @@
+---
+name: UX report
+about: Was Folding@home hard to use? It's not you, it's us. We want to hear about it.
+title: 'UX: '
+labels: 'UX report'
+assignees: ''
+
+---
+
+<!-- Did Folding@home not do what you expected?
+Was it hard to figure out how to do something?
+Could an error message be more helpful?
+It's not you, it's us. We want to hear about it. -->
+
+## What were you trying to do
+
+## What happened

--- a/.github/ISSUE_TEMPLATE/web-control-bug.md
+++ b/.github/ISSUE_TEMPLATE/web-control-bug.md
@@ -1,0 +1,23 @@
+---
+name: WebControl bug report
+about: Create a report about a bug in the Folding@home browser GUI.
+title: ''
+labels: WebControl, defect
+assignees: ''
+
+---
+
+## Environment
+
+* OS:
+* Browser version:
+* FAH version:
+
+## What were you trying to do
+<!--And what was the expected behaviour?-->
+
+## What happened
+<!--A clear and concise description of what the bug is.-->
+
+## To Reproduce
+<!--Steps to reproduce the behavior, if possible.-->


### PR DESCRIPTION
The individual repositories can [redirect their issue trackers](https://help.github.com/en/github/building-a-strong-community/configuring-issue-templates-for-your-repository#configuring-the-template-chooser) to this one, and users will have a clear idea of how to open a relevant issue that won't be lost in the crowd.