### PR TITLE
Fixed repo links

### DIFF
--- a/.github/ISSUE_TEMPLATE/Reporting-Issue.md
+++ b/.github/ISSUE_TEMPLATE/Reporting-Issue.md
@@ -15,7 +15,7 @@ If you require more general support please use the Forum: https://foldingforum.o
 Please follow the template and fill in as much of the template as possible.
 -->
 Your issue may already be reported!
-Please search on the [issue tracker](../) before creating one.
+Please search on the [issue tracker](./) before creating one.
 
 ## Your Environment
 <!---

--- a/.github/ISSUE_TEMPLATE/Suggesting-Feature.md
+++ b/.github/ISSUE_TEMPLATE/Suggesting-Feature.md
@@ -15,7 +15,7 @@ If you require more general support please use the Forum: https://foldingforum.o
 Please follow the template and fill in as much of the template as possible.
 -->
 Your issue may already be reported!
-Please search on the [issue tracker](../) before creating one.
+Please search on the [issue tracker](./) before creating one.
 
 ## Is your feature request related to a problem?
 <!--


### PR DESCRIPTION
Fixed the link to take the Donor directly to the issues tab instead of the repo hompage.